### PR TITLE
Fix for new newlines when new rdf skeleton is loaded

### DIFF
--- a/extensions/fairifier-rdf-extension/scripts/rdf-schema-alignment.js
+++ b/extensions/fairifier-rdf-extension/scripts/rdf-schema-alignment.js
@@ -218,7 +218,7 @@ RdfSchemaAlignmentDialog.prototype._renderBody = function(body) {
    // $("#rdf-schema-alignment-tabs-vocabulary-manager").css("display", "");
 
     this._canvas = $(".schema-alignment-dialog-canvas");
-    $("table.schema-alignment-table-layout").html("");
+    $("table.schema-alignment-table-layout").remove();
     this._nodeTable = $('<table></table>').addClass("schema-alignment-table-layout").addClass("rdf-schema-alignment-table-layout").appendTo(this._canvas)[0];
         
     for (var i = 0; i < this._schema.rootNodes.length; i++) {

--- a/extensions/fairifier-rdf-extension/scripts/rdf-skeleton-list.js
+++ b/extensions/fairifier-rdf-extension/scripts/rdf-skeleton-list.js
@@ -94,8 +94,4 @@ RdfSkeletonListDialog.prototype._constructBody = function(body) {
     $('<div class="preview" style="overflow:auto;height:75%;float:right;"></div></div>').appendTo(container);
     $(container).appendTo(body);
 
-//TODO: add nested node retrieval to preview (should be recursive solution)
-//    function getPropertiesOfNode(node){
-//        
-//    }
 };

--- a/module/scripts/rdf-schema-alignment.js
+++ b/module/scripts/rdf-schema-alignment.js
@@ -218,7 +218,7 @@ RdfSchemaAlignmentDialog.prototype._renderBody = function(body) {
    // $("#rdf-schema-alignment-tabs-vocabulary-manager").css("display", "");
 
     this._canvas = $(".schema-alignment-dialog-canvas");
-    $("table.schema-alignment-table-layout").html("");
+    $("table.schema-alignment-table-layout").remove();
     this._nodeTable = $('<table></table>').addClass("schema-alignment-table-layout").addClass("rdf-schema-alignment-table-layout").appendTo(this._canvas)[0];
         
     for (var i = 0; i < this._schema.rootNodes.length; i++) {


### PR DESCRIPTION
The fix was one line of code where a .html("") call had to be replaced with a .remove() call